### PR TITLE
Show total number of rows in report

### DIFF
--- a/src/pages/Reports.vue
+++ b/src/pages/Reports.vue
@@ -21,13 +21,15 @@
     <div class="row q-mt-lg">
       <div class="col">
         <div class="q-pa-md">
-        <q-table
-          title="Report"
-          :data="visits"
-          :columns="columns"
-          :loading="isReportLoading"
-          row-key="date"
-        />
+          <q-table
+            title="Report"
+            :data="visits"
+            :columns="columns"
+            :loading="isReportLoading"
+            row-key="date"
+          >
+            <template #top-right>Got {{ visits.length }} results</template>
+          </q-table>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### General
Added number of rows in the top-right of the table

### Type
- [ ] Fix
- [x] Feature

### Describe the changes here (summarized)
Added scoped slot `top-right` containing the number of rows to the `q-table` that displays the result

closes #40 