### PR TITLE
Update core-js: 3.21.1 → 3.22.0 (minor)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4868,9 +4868,9 @@
       }
     },
     "core-js": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.0.tgz",
+      "integrity": "sha512-8h9jBweRjMiY+ORO7bdWSeWfHhLPO7whobj7Z2Bl0IDo00C228EdGgH7FE4jGumbEjzcFfkfW8bXgdkEDhnwHQ=="
     },
     "core-js-compat": {
       "version": "3.6.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@quasar/extras": "^1.13.5",
     "axios": "^0.26.1",
-    "core-js": "^3.21.1",
+    "core-js": "^3.22.0",
     "papaparse": "^5.3.2",
     "quasar": "^1.18.6",
     "vue-i18n": "^8.27.1"


### PR DESCRIPTION
### What changed?

#### ✳️ core-js (3.21.1 → 3.22.0)